### PR TITLE
fix: Trigger window resize event

### DIFF
--- a/fullsize/public/js/fullsize.js
+++ b/fullsize/public/js/fullsize.js
@@ -23,6 +23,7 @@ function GoFullsize() {
 	sheet.setAttribute('id','fullsizestyle');
 	sheet.innerHTML = ".container {width: 100% !important;}";
 	document.body.appendChild(sheet);
+	window.dispatchEvent(new Event('resize'));
 	prepareBackToNormalView();
 }
 


### PR DESCRIPTION
To be used along with: https://github.com/frappe/datatable/pull/57
To notify DataTable to resize it's `bodyScrollable`.